### PR TITLE
Tailwind の warn log 対応

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-	content: ["./**/*.{html,js,vue}"],
+	content: ["!node_modules", "./**/*.{html,js,vue}"],
 	theme: {
 		extend: {
 			colors: {


### PR DESCRIPTION
下記の warn log の通り、tailwind の対象から node_modules を除外しました。

```
WARN  warn - Your content configuration includes a pattern which looks like it's accidentally matching all of node_modules and can cause serious performance issues.
```